### PR TITLE
[Feat] : 회원 복구, 비밀번호 찾기, 비밀번호 재설정 기능 구현

### DIFF
--- a/linkup/src/main/java/com/learningcrew/linkup/exception/ErrorCode.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/exception/ErrorCode.java
@@ -49,13 +49,14 @@ public enum ErrorCode {
     ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증을 거친 계정입니다"),
     INVALID_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 상태입니다."),
     INVALID_ROLE(HttpStatus.BAD_REQUEST, "올바르지 않는 권한입니다. "),
-    WITHDRAW_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 계정입니다."),
+    WITHDRAW_USER(HttpStatus.UNAUTHORIZED, "이미 탈퇴한 계정입니다."),
     ACCOUNT_NOT_RECOVERABLE(HttpStatus.BAD_REQUEST, "복구 가능한 계정이 아닙니다. "),
+    DUPLICATE_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다. "),
 
     //메일
     SEND_MAIL_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일 발송에 실패했습니다."),
     NOT_AUTHORIZED_USER_EMAIL(HttpStatus.BAD_REQUEST, "이메일이 인증되지 않아 회원 가입에 실패했습니다."),
-    EXPIRE_VERIFICATION_CODE(HttpStatus.NOT_FOUND, "인증시간이 만료되었습니다. 다시 요청해주세요."),
+    EXPIRE_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증시간이 만료되었습니다. 다시 요청해주세요."),
     TOKEN_ALREADY_SENT(HttpStatus.CONFLICT, "이미 비밀번호 재설정 이메일이 전송되었습니다. 잠시 후 다시 시도해 주세요."),
     INVALID_VERIFICATION_TOKEN(HttpStatus.BAD_REQUEST, "이메일 인증코드가 일치하지 않습니다. "),
     INVALID_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "이메일 타입이 일치하지 않습니다."),

--- a/linkup/src/main/java/com/learningcrew/linkup/exception/ErrorCode.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/exception/ErrorCode.java
@@ -49,6 +49,8 @@ public enum ErrorCode {
     ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증을 거친 계정입니다"),
     INVALID_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 상태입니다."),
     INVALID_ROLE(HttpStatus.BAD_REQUEST, "올바르지 않는 권한입니다. "),
+    WITHDRAW_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 계정입니다."),
+    ACCOUNT_NOT_RECOVERABLE(HttpStatus.BAD_REQUEST, "복구 가능한 계정이 아닙니다. "),
 
     //메일
     SEND_MAIL_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "메일 발송에 실패했습니다."),

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/controller/UserAccountCommandController.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/controller/UserAccountCommandController.java
@@ -1,12 +1,12 @@
 package com.learningcrew.linkup.linker.command.application.controller;
 
+import com.learningcrew.linkup.linker.command.application.dto.request.UserRecoverRequestDTO;
 import com.learningcrew.linkup.linker.command.application.dto.request.FindPasswordRequest;
 import com.learningcrew.linkup.linker.command.application.dto.request.LoginRequest;
 import com.learningcrew.linkup.linker.command.application.dto.request.UserCreateRequest;
 import com.learningcrew.linkup.linker.command.application.dto.request.WithdrawUserRequest;
 import com.learningcrew.linkup.linker.command.application.dto.response.RegisterResponse;
 import com.learningcrew.linkup.linker.command.application.service.AccountCommandService;
-import com.learningcrew.linkup.linker.command.application.service.AccountCommandServiceImpl;
 import com.learningcrew.linkup.common.dto.ApiResponse;
 import com.learningcrew.linkup.security.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,22 +56,9 @@ public class UserAccountCommandController {
 
     /* 계정 복구 */
     @PostMapping("/recover")
-    public ResponseEntity<ApiResponse<Void>> recoverUser(){
-        return null;
-    }
-
-    /* 비밀번호 찾기 - 비밀번호 재설정 url 발송 */
-    @PostMapping("/send-pw-reset-url")
-    @Operation(summary = "비밀번호 재설정 URL 발송", description = "이메일과 휴대폰로 비밀번호 재설정 url을 이메일로 발송")
-    public ResponseEntity<ApiResponse<Void>> sendPasswordResetUrl(@Valid @RequestBody FindPasswordRequest request) {
-        return null;
-    }
-
-    /* 비밀번호 재설정 */
-    @PostMapping("/reset-password")
-    public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody LoginRequest request) {
-        log.info("비밀번호 재설정 URL 요청: email={}, contact={}", request.getEmail());
-        return null;
+    public ResponseEntity<ApiResponse<Void>> recoverUser(@RequestBody UserRecoverRequestDTO request){
+        userCommandService.recoverUser(request.getEmail(),request.getPassword());
+        return ResponseEntity.ok(ApiResponse.success(null,"계정이 복구되었습니다."));
     }
 
 

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/controller/UserAuthCommandController.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/controller/UserAuthCommandController.java
@@ -1,11 +1,13 @@
 package com.learningcrew.linkup.linker.command.application.controller;
 
 import com.learningcrew.linkup.common.dto.ApiResponse;
+import com.learningcrew.linkup.linker.command.application.dto.request.ResetPasswordRequest;
+import com.learningcrew.linkup.linker.command.application.dto.request.FindPasswordRequest;
 import com.learningcrew.linkup.linker.command.application.dto.request.LoginRequest;
 import com.learningcrew.linkup.linker.command.application.dto.request.RefreshTokenRequest;
 import com.learningcrew.linkup.linker.command.application.dto.response.TokenResponse;
 import com.learningcrew.linkup.linker.command.application.service.AuthCommandService;
-import com.learningcrew.linkup.linker.command.application.service.AuthCommandServiceImpl;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,6 +59,21 @@ public class UserAuthCommandController {
         userAuthCommandService.logout(request.getRefreshToken());
         log.info("로그아웃 처리 완료: refreshToken 삭제됨");
         return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    /* 비밀번호 찾기 - 비밀번호 재설정 url 발송 */
+    @PostMapping("/password/reset-link")
+    @Operation(summary = "비밀번호 재설정 URL 발송", description = "이메일 조회 후 재설정 url을 이메일로 발송")
+    public ResponseEntity<ApiResponse<Void>> sendPasswordResetUrl(@Valid @RequestBody FindPasswordRequest request) {
+        userAuthCommandService.sendPasswordResetLink(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success(null, "비밀번호 재설정 메일을 전송했습니다."));
+    }
+
+    /* 비밀번호 재설정 */
+    @PostMapping("/password/reset")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        log.info("비밀번호 재설정 요청: email={}, token={}", request.getEmail(), request.getToken());
+        return ResponseEntity.ok(ApiResponse.success(null, "비밀번호가 변경되었습니다."));
     }
 
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/controller/UserAuthCommandController.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/controller/UserAuthCommandController.java
@@ -56,7 +56,7 @@ public class UserAuthCommandController {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(@Valid @RequestBody RefreshTokenRequest request){
         log.info("로그아웃 요청: refreshToken={}", request.getRefreshToken());
-        userAuthCommandService.logout(request.getRefreshToken());
+        userAuthCommandService.logout(request);
         log.info("로그아웃 처리 완료: refreshToken 삭제됨");
         return ResponseEntity.ok(ApiResponse.success(null));
     }
@@ -65,14 +65,15 @@ public class UserAuthCommandController {
     @PostMapping("/password/reset-link")
     @Operation(summary = "비밀번호 재설정 URL 발송", description = "이메일 조회 후 재설정 url을 이메일로 발송")
     public ResponseEntity<ApiResponse<Void>> sendPasswordResetUrl(@Valid @RequestBody FindPasswordRequest request) {
-        userAuthCommandService.sendPasswordResetLink(request.getEmail());
+        userAuthCommandService.sendPasswordResetLink(request);
         return ResponseEntity.ok(ApiResponse.success(null, "비밀번호 재설정 메일을 전송했습니다."));
     }
 
     /* 비밀번호 재설정 */
     @PostMapping("/password/reset")
     public ResponseEntity<ApiResponse<Void>> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
-        log.info("비밀번호 재설정 요청: email={}, token={}", request.getEmail(), request.getToken());
+        log.info("비밀번호 재설정 요청: email={}, token={}, password={}", request.getEmail(), request.getToken(), request.getNewPassword());
+        userAuthCommandService.resetPassword(request);
         return ResponseEntity.ok(ApiResponse.success(null, "비밀번호가 변경되었습니다."));
     }
 

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/FindPasswordRequest.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/FindPasswordRequest.java
@@ -1,6 +1,8 @@
 package com.learningcrew.linkup.linker.command.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -8,4 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Schema(description = "비밀번호 찾기 요청 DTO")
 public class FindPasswordRequest {
+    @Email
+    @NotBlank
+    @Schema(description = "이메일", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String email;
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/LoginRequest.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/LoginRequest.java
@@ -3,6 +3,7 @@ package com.learningcrew.linkup.linker.command.application.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/ResetPasswordRequest.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/ResetPasswordRequest.java
@@ -3,6 +3,7 @@ package com.learningcrew.linkup.linker.command.application.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -16,12 +17,12 @@ public class ResetPasswordRequest {
     private String email;
 
     @NotBlank
-    @NotBlank
     @Schema(description = "비밀번호 재설정 토큰", requiredMode = Schema.RequiredMode.REQUIRED)
     private String token;
 
     @NotBlank
-    @NotBlank
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,20}$",
+            message = "비밀번호는 영문자, 숫자, 특수문자를 포함한 8~20자리여야 합니다.")
     @Schema(description = "새로운 비밀번호", requiredMode = Schema.RequiredMode.REQUIRED)
     private String newPassword;
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/ResetPasswordRequest.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,27 @@
+package com.learningcrew.linkup.linker.command.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ResetPasswordRequest {
+
+    @Email
+    @NotBlank
+    @Schema(description = "이메일", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String email;
+
+    @NotBlank
+    @NotBlank
+    @Schema(description = "비밀번호 재설정 토큰", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String token;
+
+    @NotBlank
+    @NotBlank
+    @Schema(description = "새로운 비밀번호", requiredMode = Schema.RequiredMode.REQUIRED)
+    private String newPassword;
+}

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/ResetPasswordRequest.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/ResetPasswordRequest.java
@@ -1,4 +1,4 @@
-package com.learningcrew.linkup.linker.command.application.dto;
+package com.learningcrew.linkup.linker.command.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/UserRecoverRequestDTO.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/UserRecoverRequestDTO.java
@@ -1,0 +1,4 @@
+package com.learningcrew.linkup.linker.command.application.dto;
+
+public class UserRecoverRequestDTO {
+}

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/UserRecoverRequestDTO.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/UserRecoverRequestDTO.java
@@ -1,4 +1,18 @@
-package com.learningcrew.linkup.linker.command.application.dto;
+package com.learningcrew.linkup.linker.command.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "회원 복구 요청 DTO")
 public class UserRecoverRequestDTO {
+    @Schema(description = "이메일",  requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "복구신청할 이메일을 필수적으로 입력해주세요")
+    String email;
+    @Schema(description = "비밀번호",  requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "비밀번호를 필수적으로 입력해주세요")
+    String password;
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/WithdrawUserRequest.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/dto/request/WithdrawUserRequest.java
@@ -1,6 +1,7 @@
 package com.learningcrew.linkup.linker.command.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -8,5 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Schema(description = "회원 탈퇴 요청 DTO")
 public class WithdrawUserRequest {
+    @Schema(description = "비밀번호",  requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "비밀번호를 필수적으로 입력해주세요")
     private String password;
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AccountCommandService.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AccountCommandService.java
@@ -3,12 +3,15 @@ package com.learningcrew.linkup.linker.command.application.service;
 import com.learningcrew.linkup.linker.command.application.dto.request.UserCreateRequest;
 import com.learningcrew.linkup.linker.command.application.dto.request.WithdrawUserRequest;
 import com.learningcrew.linkup.linker.command.application.dto.response.RegisterResponse;
+import jakarta.validation.constraints.NotBlank;
 
 public interface AccountCommandService {
 
     RegisterResponse registerUser(UserCreateRequest request);
 
     void withdrawUser(String password,int userId);
+
+    void recoverUser(String email, String password);
 
     // void verifyEmail(...);
     // void updateProfile(...);

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AccountCommandServiceImpl.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AccountCommandServiceImpl.java
@@ -97,6 +97,7 @@ public class AccountCommandServiceImpl implements AccountCommandService {
         userRepository.save(user);
     }
 
+    /* 회원 계정 복구 */
     @Override
     @Transactional
     public void recoverUser(String email, String password) {

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AccountCommandServiceImpl.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AccountCommandServiceImpl.java
@@ -6,14 +6,13 @@ import com.learningcrew.linkup.exception.ErrorCode;
 import com.learningcrew.linkup.linker.command.application.dto.response.RegisterResponse;
 import com.learningcrew.linkup.linker.command.domain.aggregate.Member;
 import com.learningcrew.linkup.linker.command.domain.aggregate.User;
+import com.learningcrew.linkup.linker.command.domain.constants.EmailTokenType;
 import com.learningcrew.linkup.linker.command.domain.constants.LinkerStatusType;
 import com.learningcrew.linkup.linker.command.domain.repository.UserRepository;
 import com.learningcrew.linkup.linker.command.application.dto.request.UserCreateRequest;
 import com.learningcrew.linkup.linker.command.domain.service.MemberDomainServiceImpl;
 import com.learningcrew.linkup.linker.command.domain.service.UserDomainServiceImpl;
 import com.learningcrew.linkup.linker.command.domain.service.UserValidatorServiceImpl;
-import com.learningcrew.linkup.linker.query.dto.query.UserDeleteDTO;
-import com.learningcrew.linkup.linker.query.mapper.UserMapper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -30,7 +29,6 @@ public class AccountCommandServiceImpl implements AccountCommandService {
     private final UserDomainServiceImpl userDomainService;
     private final MemberDomainServiceImpl memberDomainService;
     private final EmailService emailService;
-    private final UserMapper userMapper;
 
 
     /* 유저 생성 - 회원 가입 */
@@ -52,8 +50,6 @@ public class AccountCommandServiceImpl implements AccountCommandService {
         //상태 부여
         userDomainService.assignStatus(user, "PENDING");
 
-        userDomainService.saveUser(user);
-
         // User 엔티티 생성 및 저장
         userRepository.save(user);
 
@@ -69,7 +65,7 @@ public class AccountCommandServiceImpl implements AccountCommandService {
         memberDomainService.saveMember(member, user.getUserId());
 
         // 이메일 전송 및 저장
-        emailService.sendVerificationCode(user.getUserId(), user.getEmail(), user.getUserName());
+        emailService.sendVerificationCode(user.getUserId(), user.getEmail(), user.getUserName(), EmailTokenType.REGISTER.name());
 
         return RegisterResponse
                 .builder()
@@ -98,6 +94,29 @@ public class AccountCommandServiceImpl implements AccountCommandService {
         user.setDeletedAt();
 
         //저장
+        userRepository.save(user);
+    }
+
+    @Override
+    @Transactional
+    public void recoverUser(String email, String password) {
+        // 회원 조회
+        User user = userRepository.findByEmail(email).orElseThrow(
+                () -> new BusinessException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        // 비밀번호 검사
+        userValidatorService.validatePassword(password, user.getPassword());
+
+        // 계정 복구 유효기간(90일) 넘었는지 확인
+        userValidatorService.isWithinRecoveryPeriod(user.getStatus().getStatusType(), user.getDeletedAt());
+
+        // 상태 활성화
+        userDomainService.assignStatus(user,LinkerStatusType.ACCEPTED.name());
+
+        // 삭제일시 초기화
+        user.setDeletedAt(null);
+
         userRepository.save(user);
     }
 

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AuthCommandService.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AuthCommandService.java
@@ -1,7 +1,11 @@
 package com.learningcrew.linkup.linker.command.application.service;
 
+import com.learningcrew.linkup.linker.command.application.dto.request.FindPasswordRequest;
 import com.learningcrew.linkup.linker.command.application.dto.request.LoginRequest;
+import com.learningcrew.linkup.linker.command.application.dto.request.RefreshTokenRequest;
+import com.learningcrew.linkup.linker.command.application.dto.request.ResetPasswordRequest;
 import com.learningcrew.linkup.linker.command.application.dto.response.TokenResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
@@ -11,9 +15,11 @@ public interface AuthCommandService {
 
     TokenResponse refreshToken(String providedRefreshToken);
 
-    void logout(String refreshToken);
+    void logout(@Valid RefreshTokenRequest request);
 
-    void verifyEmail(String tokenCode);
+    void sendPasswordResetLink(@Valid FindPasswordRequest request);
 
-    void sendPasswordResetLink(@Email @NotBlank String email);
+    void resetPassword(@Valid ResetPasswordRequest request);
+
+    void verifyEmail(String token);
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AuthCommandService.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/AuthCommandService.java
@@ -2,6 +2,8 @@ package com.learningcrew.linkup.linker.command.application.service;
 
 import com.learningcrew.linkup.linker.command.application.dto.request.LoginRequest;
 import com.learningcrew.linkup.linker.command.application.dto.response.TokenResponse;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 
 public interface AuthCommandService {
 
@@ -12,4 +14,6 @@ public interface AuthCommandService {
     void logout(String refreshToken);
 
     void verifyEmail(String tokenCode);
+
+    void sendPasswordResetLink(@Email @NotBlank String email);
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/EmailService.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/EmailService.java
@@ -1,6 +1,6 @@
 package com.learningcrew.linkup.linker.command.application.service;
 
 public interface EmailService {
-    void sendVerificationCode(int userId, String email, String userName);
+    void sendVerificationCode(int userId, String email, String userName, String verificationCode);
 }
 

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/EmailServiceImpl.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/application/service/EmailServiceImpl.java
@@ -21,21 +21,38 @@ import java.time.format.DateTimeFormatter;
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
     private final JavaMailSender mailSender;
-    private final UserDomainServiceImpl userDomainService;
     private final SpringTemplateEngine templateEngine;
     private final VerificationTokenServiceImpl verificationTokenService;
 
     private static final int codeValidTime = 10; // 인증 코드 유효 시간 (10분)
     /* 회원가입 인증코드 전송 */
-    public void sendVerificationCode(int userId, String email, String userName) {
-        log.info("========인증코드 발송 서비스 - sendSignUpEmail : email: {}========", email);
+    public void sendVerificationCode(int userId, String email, String userName, String tokenType) {
+        log.info("========인증코드 발송 서비스 - sendSignUpEmail : email: {}, userName: {}, tokenType: {} ========", email,userName,tokenType );
 
+        String subject;
+        String templateName;
+
+        switch (tokenType) {
+            case "REGISTER" -> {
+                subject = "[Linker] 회원가입 인증코드입니다.";
+                templateName = "email/verification-code";
+            }
+            case "RESET_PASSWORD" -> {
+                subject = "[Linker] 비밀번호 재설정 링크입니다.";
+                templateName = "email/password-reset"; // 필요시 새 템플릿
+            }
+            case "ACCOUNT_RECOVERY" -> {
+                subject = "[Linker] 계정 복구 인증코드입니다.";
+                templateName = "email/recovery-code";
+            }
+            default -> throw new BusinessException(ErrorCode.INVALID_TOKEN_TYPE);
+        }
         // 인증 코드 저장
-        String subject = "[Linker] 회원가입 인증코드입니다.";
-        String verificationCode = verificationTokenService.createAndSaveToken(userId, email, "REGISTER");
+        String verificationCode = verificationTokenService.createAndSaveToken(userId, email, tokenType);
 
         // 인증 코드 만료 시간 설정
-        LocalDateTime expireMinute = LocalDateTime.now().plusMinutes(codeValidTime);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        String expireMinute = LocalDateTime.now().plusMinutes(codeValidTime).format(formatter);
 
         // 이메일 전송
         MimeMessage message = mailSender.createMimeMessage();
@@ -47,12 +64,10 @@ public class EmailServiceImpl implements EmailService {
             Context context = new org.thymeleaf.context.Context();
             context.setVariable("userName", userName);
             context.setVariable("verificationCode", verificationCode);
+            context.setVariable("email", email);
+            context.setVariable("expireTime", expireMinute + "분");
 
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-            context.setVariable("expireTime", expireMinute.format(formatter) + "분");
-
-            String htmlContent = templateEngine.process("email/verification-code", context);
+            String htmlContent = templateEngine.process(templateName, context);
             helper.setText(htmlContent, true);
 
             mailSender.send(message);

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/aggregate/RefreshToken.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/aggregate/RefreshToken.java
@@ -18,6 +18,7 @@ import java.util.Date;
 @AllArgsConstructor
 public class RefreshToken {
     @Id
+    private int userId;
     private String userEmail;
     private String token;
     private Date expiryDate;

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/aggregate/User.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/aggregate/User.java
@@ -35,7 +35,6 @@ public class User {
 
     @CreatedDate
     private LocalDateTime createdAt;
-    @LastModifiedDate
     private LocalDateTime deletedAt;
 
     @ManyToOne
@@ -59,5 +58,9 @@ public class User {
 
     public void setDeletedAt() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
     }
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/constants/EmailTokenType.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/constants/EmailTokenType.java
@@ -1,0 +1,7 @@
+package com.learningcrew.linkup.linker.command.domain.constants;
+
+public enum EmailTokenType {
+    REGISTER,
+    RESET_PASSWORD,
+    ACCOUNT_RECOVERY
+}

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/TokenDomainService.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/TokenDomainService.java
@@ -5,5 +5,5 @@ import com.learningcrew.linkup.linker.command.domain.aggregate.User;
 public interface TokenDomainService {
     String generateToken(User user);
     String generateRefreshToken(User user);
-    void saveRefreshToken(String email, String refreshToken);
+    void saveRefreshToken(int userId, String email, String refreshToken);
 }

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/TokenDomainServiceImpl.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/TokenDomainServiceImpl.java
@@ -24,8 +24,9 @@ public class TokenDomainServiceImpl implements TokenDomainService {
         return jwtTokenProvider.createRefreshToken(user.getEmail(), user.getRole().getRoleName());
     }
 
-    public void saveRefreshToken(String email, String refreshToken) {
+    public void saveRefreshToken(int userId, String email, String refreshToken) {
         RefreshToken refreshTokenEntity = RefreshToken.builder()
+                .userId(userId)
                 .userEmail(email)
                 .token(refreshToken)
                 .expiryDate(new Date(System.currentTimeMillis() + jwtTokenProvider.getRefreshTokenExpiration()))

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/UserValidatorServiceImpl.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/UserValidatorServiceImpl.java
@@ -5,11 +5,15 @@ import com.learningcrew.linkup.common.query.mapper.StatusMapper;
 import com.learningcrew.linkup.exception.BusinessException;
 import com.learningcrew.linkup.exception.ErrorCode;
 import com.learningcrew.linkup.linker.command.domain.aggregate.User;
+import com.learningcrew.linkup.linker.command.domain.constants.LinkerStatusType;
 import com.learningcrew.linkup.linker.command.domain.repository.MemberRepository;
 import com.learningcrew.linkup.linker.command.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +57,21 @@ public class UserValidatorServiceImpl {
                 .orElseThrow(
                         () -> new BusinessException(ErrorCode.INVALID_CREDENTIALS)
                 );
+    }
+
+    public void isWithinRecoveryPeriod(String statusType, LocalDateTime deletedAt) {
+        // 삭제된 회원인지 확인
+        if (Objects.isNull(deletedAt) || !statusType.equals(LinkerStatusType.DELETED.name())) {
+            throw new BusinessException(ErrorCode.ACCOUNT_NOT_RECOVERABLE);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiry = deletedAt.plusDays(90);
+
+        // 복구 유효기간 내 회원인지 확인
+        if(!now.isBefore(expiry)){
+            throw new BusinessException(ErrorCode.ACCOUNT_NOT_RECOVERABLE);
+        }
     }
 }
 

--- a/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/UserValidatorServiceImpl.java
+++ b/linkup/src/main/java/com/learningcrew/linkup/linker/command/domain/service/UserValidatorServiceImpl.java
@@ -4,6 +4,7 @@ import com.learningcrew.linkup.common.domain.Status;
 import com.learningcrew.linkup.common.query.mapper.StatusMapper;
 import com.learningcrew.linkup.exception.BusinessException;
 import com.learningcrew.linkup.exception.ErrorCode;
+import com.learningcrew.linkup.exception.security.CustomJwtException;
 import com.learningcrew.linkup.linker.command.domain.aggregate.User;
 import com.learningcrew.linkup.linker.command.domain.constants.LinkerStatusType;
 import com.learningcrew.linkup.linker.command.domain.repository.MemberRepository;
@@ -51,6 +52,12 @@ public class UserValidatorServiceImpl {
         }
     }
 
+    public void validateDuplicatePassword(String rawPassword, String encodedPassword) {
+        if (passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_PASSWORD);
+        }
+    }
+
     /* 이메일 인증 검사 */
     public User validateEmail(String email) {
         return userRepository.findByEmail(email)
@@ -71,6 +78,18 @@ public class UserValidatorServiceImpl {
         // 복구 유효기간 내 회원인지 확인
         if(!now.isBefore(expiry)){
             throw new BusinessException(ErrorCode.ACCOUNT_NOT_RECOVERABLE);
+        }
+    }
+
+    public void validateUserStatus(String providedStatus, String targetStatus) {
+        if(!(providedStatus.equals(targetStatus))) {
+            throw new BusinessException(ErrorCode.NOT_AUTHORIZED_USER_EMAIL);
+        }
+    }
+
+    public void isDeletedUser(LocalDateTime userDeletedAt){
+        if(Objects.nonNull(userDeletedAt)){
+            throw new BusinessException(ErrorCode.WITHDRAW_USER);
         }
     }
 }

--- a/linkup/src/main/resources/templates/email/password-reset.html
+++ b/linkup/src/main/resources/templates/email/password-reset.html
@@ -2,23 +2,25 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>회원가입 인증코드 안내</title>
+    <title>비밀번호 재설정 안내</title>
 </head>
 <body>
 <div style="font-family: Arial, sans-serif; padding: 20px;">
     <h2 th:text="'안녕하세요, ' + ${userName} + '님!'">안녕하세요, [이름]님!</h2>
-    <p>
-        저희 <strong>LinkUp</strong> 서비스를 이용해 주셔서 감사합니다. <br/>
-        아래 인증코드를 입력하여 회원가입을 완료해 주세요.
-    </p>
+
+    <p>요청하신 <strong>비밀번호 재설정</strong> 링크를 아래에 안내드립니다.</p>
+
+    <p>아래 버튼을 클릭하여 비밀번호를 재설정해주세요.</p>
+
     <div style="margin: 20px 0; padding: 30px; background-color: #ffffff; text-align: center;">
-        <a th:href="@{http://localhost:8080/api/v1/auth/verify-email(token=${verificationCode})}"
+        <a class="btn"
+           th:href="@{http://localhost:3000/reset-password(email=${email}, token=${verificationCode})}"
            style="padding: 10px 20px; background-color: #1fbfff; color: white; text-decoration: none; border-radius: 4px;">
-            이메일 인증하기
+            비밀번호 재설정
         </a>
 
         <p style="margin-top: 24px">해당 인증코드는 <strong th:text="${expireTime}">10분</strong> 까지 유효합니다.</p>
-    <hr/>
+        <hr/>
     </div>
 
     <p class="footer">


### PR DESCRIPTION
closes #87 
closes #84 
closes #82 

### 개요
- 탈퇴한 계정 복구 기능
- 비밀번호 찾기 요청 시 이메일을 통한 비밀번호 재설정 링크 발송
- 재설정 링크를 통한 비밀번호 재설정 기능

### 변경사항
1. 계정 복구 (/account/recover)
deletedAt 이 존재하는 계정에 대해

복구 요청 시점이 90일 이내인지 검증

비밀번호 일치 여부 확인

상태(Status) 변경 → ACCEPTED

deletedAt 초기화 처리

2. 비밀번호 찾기 (/password/reset-link)
사용자가 입력한 이메일에 대해 사용자 존재 여부 검증

RESET_PASSWORD 토큰 생성 및 저장

이메일을 통해 비밀번호 재설정 링크 전송

토큰 및 이메일을 포함한 URL 생성

유효 시간 10분 설정

3. 비밀번호 재설정 (/password/reset)
전달된 토큰 + 이메일 기반으로 토큰 유효성 검증

토큰 존재 여부, 타입, 만료 여부 확인

새로운 비밀번호 유효성 검증 및 암호화 저장

기존 비밀번호와 중복 여부 확인 포함

비밀번호 변경 완료 후, 사용된 토큰 삭제